### PR TITLE
Bump to version 1.0.1 for apple version update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## 2024-06-17 - v1.0.0(32)
+## 2024-06-17 - v1.0.1(1)
+- Update about text in iOS build
 
+## 2024-06-17 - v1.0.0(32)
 - Update about text
 
 ## 2024-06-15 - v1.0.0(31)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: autogram
 description: "Autogram v mobile"
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-version: 1.0.0+32
+version: 1.0.1+1
 
 environment:
   sdk: '>=3.2.3 <4.0.0'


### PR DESCRIPTION
iOS appka pri update už musela mať iné číslo verzie, tak to syncujem sem na GitHub. Toto je posledný "divoký" PR. Po ňom nastavím riadne branch protection rules 🙂 