### PR TITLE
Umoznit sharovat subor ak na Android neexistuje Downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## NEXT - v1.0.2(33)
  
-- Refactor Settings model 
+- Refactor Settings model
+- #18 | Allow sharing signed Document even when failed to save file
 
 ## 2024-06-17 - v1.0.1(1)
  

--- a/lib/bloc/present_signed_document_cubit.dart
+++ b/lib/bloc/present_signed_document_cubit.dart
@@ -18,6 +18,9 @@ import 'present_signed_document_state.dart';
 export 'present_signed_document_state.dart';
 
 /// Cubit for [PresentSignedDocumentScreen].
+///
+/// Allows saving document into public directory or getting [File]
+/// instance so it can be shared.
 @injectable
 class PresentSignedDocumentCubit extends Cubit<PresentSignedDocumentState> {
   static final _log = Logger("PresentSignedDocumentCubit");
@@ -33,6 +36,7 @@ class PresentSignedDocumentCubit extends Cubit<PresentSignedDocumentState> {
   })  : _appService = appService,
         super(const PresentSignedDocumentInitialState());
 
+  /// Saves [signedDocument] into public directory.
   Future<void> saveDocument() async {
     _log.info("Saving signed document: ${signedDocument.filename}.");
 
@@ -72,6 +76,8 @@ class PresentSignedDocumentCubit extends Cubit<PresentSignedDocumentState> {
       }
     }
 
+    // TODO Unify naming of "getShareableFile" and "_getTargetFile" - this returns also File with content while 2nd only File path
+
     final name = signedDocument.filename;
     final directory = await getTemporaryDirectory();
     final path = p.join(directory.path, name);
@@ -83,14 +89,14 @@ class PresentSignedDocumentCubit extends Cubit<PresentSignedDocumentState> {
     return file.writeAsBytes(bytes, flush: true);
   }
 
-  /// Returns target [File] where to save new file from [signedDocument].
+  /// Returns [File], where [signedDocument] content should be saved.
   ///
   /// See also:
   ///  - [getTargetFileName]
   Future<File> _getTargetFile() async {
     final directory = await _appService.getDocumentsDirectory();
 
-    // Attempt to crete if not exists
+    // Attempt to create Directory if not exists
     if (!(await directory.exists()) && Platform.isAndroid) {
       await directory.create(recursive: true);
     }

--- a/lib/bloc/present_signed_document_cubit.dart
+++ b/lib/bloc/present_signed_document_cubit.dart
@@ -45,6 +45,7 @@ class PresentSignedDocumentCubit extends Cubit<PresentSignedDocumentState> {
       final bytes = await Future.microtask(
         () => base64Decode(signedDocument.content),
       );
+      // TODO Catch and still allow sharing
       await file.writeAsBytes(bytes);
 
       _log.info("Signed Document was saved into $file");
@@ -86,6 +87,7 @@ class PresentSignedDocumentCubit extends Cubit<PresentSignedDocumentState> {
   /// See also:
   ///  - [getTargetFileName]
   Future<File> _getTargetFile() async {
+    // TODO Create if NOT exists (Android)
     final directory = await _appService.getDocumentsDirectory();
     final name = getTargetFileName(signedDocument.filename);
     final path = p.join(directory.path, name);

--- a/lib/pages/test_page.dart
+++ b/lib/pages/test_page.dart
@@ -15,6 +15,7 @@ import 'package:share_plus/share_plus.dart';
 
 import '../utils.dart' as utils;
 
+// TODO Move to ui/screens, add some docs
 class TestPage extends HookWidget {
   const TestPage({super.key});
 

--- a/lib/ui/screens/present_signed_document_screen.dart
+++ b/lib/ui/screens/present_signed_document_screen.dart
@@ -153,7 +153,7 @@ class _Body extends StatelessWidget {
       PresentSignedDocumentLoadingState _ => const LoadingContent(),
       PresentSignedDocumentErrorState _ => _SuccessContent(
           file: null,
-          onShareFileRequested: null,
+          onShareFileRequested: onShareFileRequested,
           onCloseRequested: onCloseRequested,
         ),
       PresentSignedDocumentSuccessState state => _SuccessContent(

--- a/lib/ui/screens/present_signed_document_screen.dart
+++ b/lib/ui/screens/present_signed_document_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:developer' as developer;
 import 'dart:io' show File, OSError, PathAccessException;
 
 import 'package:autogram_sign/autogram_sign.dart' show SignDocumentResponseBody;
@@ -20,7 +21,8 @@ import '../widgets/result_view.dart';
 
 /// Screen for presenting signed document.
 ///
-/// When [signingType] is [DocumentSigningType.local], then document is saved.
+/// When [signingType] is [DocumentSigningType.local], then document is saved
+/// into this device and also "Share" button is visible.
 ///
 /// Uses [PresentSignedDocumentCubit].
 class PresentSignedDocumentScreen extends StatelessWidget {
@@ -146,6 +148,10 @@ class _Body extends StatelessWidget {
   }
 
   Widget _getChild(BuildContext context) {
+    final sharingEnabled = (signingType == DocumentSigningType.local);
+    final onShareFileRequested =
+        sharingEnabled ? this.onShareFileRequested : null;
+
     return switch (state) {
       PresentSignedDocumentInitialState _ => _SuccessContent(
           file: null,
@@ -259,7 +265,12 @@ Widget previewInitialPresentSignedDocumentScreen(BuildContext context) {
   return _Body(
     state: const PresentSignedDocumentInitialState(),
     signingType: signingType,
-    onCloseRequested: () {},
+    onShareFileRequested: () {
+      developer.log('onShareFileRequested');
+    },
+    onCloseRequested: () {
+      developer.log('onCloseRequested');
+    },
   );
 }
 
@@ -278,6 +289,12 @@ Widget previewLoadingPresentSignedDocumentScreen(BuildContext context) {
   return _Body(
     state: const PresentSignedDocumentLoadingState(),
     signingType: signingType,
+    onShareFileRequested: () {
+      developer.log('onShareFileRequested');
+    },
+    onCloseRequested: () {
+      developer.log('onCloseRequested');
+    },
   );
 }
 
@@ -293,7 +310,7 @@ Widget previewErrorPresentSignedDocumentScreen(BuildContext context) {
     initialOption: DocumentSigningType.local,
   );
 
-  // TODO Should preview whole Screen class also with BlocConsumer.listener
+  // TODO Should preview whole Screen class also with BlocConsumer.listener to display error in SnackBar
   const error = PathAccessException(
     "/storage/emulated/0/Download/container-signed-xades-baseline-b.sce",
     OSError("Permission denied", 13),
@@ -303,8 +320,12 @@ Widget previewErrorPresentSignedDocumentScreen(BuildContext context) {
   return _Body(
     state: const PresentSignedDocumentErrorState(error),
     signingType: signingType,
-    onShareFileRequested: () {},
-    onCloseRequested: () {},
+    onShareFileRequested: () {
+      developer.log('onShareFileRequested');
+    },
+    onCloseRequested: () {
+      developer.log('onCloseRequested');
+    },
   );
 }
 
@@ -328,9 +349,11 @@ Widget previewSuccessPresentSignedDocumentScreen(BuildContext context) {
   return _Body(
     state: PresentSignedDocumentSuccessState(file),
     signingType: signingType,
-    // TODO Put logic into _Body itself!
-    onShareFileRequested:
-        signingType == DocumentSigningType.local ? () {} : null,
-    onCloseRequested: () {},
+    onShareFileRequested: () {
+      developer.log('onShareFileRequested');
+    },
+    onCloseRequested: () {
+      developer.log('onCloseRequested');
+    },
   );
 }

--- a/lib/ui/screens/present_signed_document_screen.dart
+++ b/lib/ui/screens/present_signed_document_screen.dart
@@ -20,6 +20,8 @@ import '../widgets/result_view.dart';
 
 /// Screen for presenting signed document.
 ///
+/// When [signingType] is [DocumentSigningType.local], then document is saved.
+///
 /// Uses [PresentSignedDocumentCubit].
 class PresentSignedDocumentScreen extends StatelessWidget {
   final SignDocumentResponseBody signedDocument;
@@ -326,6 +328,7 @@ Widget previewSuccessPresentSignedDocumentScreen(BuildContext context) {
   return _Body(
     state: PresentSignedDocumentSuccessState(file),
     signingType: signingType,
+    // TODO Put logic into _Body itself!
     onShareFileRequested:
         signingType == DocumentSigningType.local ? () {} : null,
     onCloseRequested: () {},

--- a/lib/ui/screens/sign_document_screen.dart
+++ b/lib/ui/screens/sign_document_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:autogram_sign/autogram_sign.dart'
     show SignDocumentResponseBody, SignDocumentResponseBodyMimeType;
 import 'package:eidmsdk/types.dart' show Certificate;
@@ -141,8 +143,11 @@ Widget previewLoadingSignDocumentScreen(BuildContext context) {
   type: SignDocumentScreen,
 )
 Widget previewErrorSignDocumentScreen(BuildContext context) {
-  return const _Body(
-    state: SignDocumentErrorState("Error message!"),
+  return _Body(
+    state: const SignDocumentErrorState("Error message!"),
+    onRetryRequested: () {
+      developer.log('onRetryRequested');
+    },
   );
 }
 
@@ -152,8 +157,8 @@ Widget previewErrorSignDocumentScreen(BuildContext context) {
   type: SignDocumentScreen,
 )
 Widget previewSuccessSignDocumentScreen(BuildContext context) {
-  return const _Body(
-    state: SignDocumentSuccessState(
+  return _Body(
+    state: const SignDocumentSuccessState(
       SignDocumentResponseBody(
         filename: "document.pdf",
         mimeType: SignDocumentResponseBodyMimeType.applicationPdfBase64,
@@ -162,5 +167,8 @@ Widget previewSuccessSignDocumentScreen(BuildContext context) {
         signedBy: "",
       ),
     ),
+    onRetryRequested: () {
+      developer.log('onRetryRequested');
+    },
   );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -767,10 +767,10 @@ packages:
     dependency: "direct main"
     description:
       name: pdf
-      sha256: "243f05342fc0bdf140eba5b069398985cdbdd3dbb1d776cf43d5ea29cc570ba6"
+      sha256: "81d5522bddc1ef5c28e8f0ee40b71708761753c163e0c93a40df56fd515ea0f0"
       url: "https://pub.dev"
     source: hosted
-    version: "3.10.8"
+    version: "3.11.0"
   pdf_widget_wrapper:
     dependency: transitive
     description:


### PR DESCRIPTION
Po uspesnom podpise, na screene, kde sa prezentuje podpisany dokument (`PresentSignedDocumentCubit`) sa pokusa ulozit file do "Downloads" / "Documents".

Na **Android**-e je to folder [`Download`](https://developer.android.com/reference/android/os/Environment#DIRECTORY_DOWNLOADS).
Ak neexistuje, pokusi sa ho vytvorit.
Ak aj to zlyha, a subor nebude mozne tam ulozit, nezobrazi sa text s uspesne ulozenym suborom, ale **Share** button bude stale dostupny, takze user s tym moze narabat dalej.

Fix #18 