### PR TITLE
Nastavenie file name pri sharovani podpisaneho suboru

### DIFF
--- a/lib/bloc/present_signed_document_cubit.dart
+++ b/lib/bloc/present_signed_document_cubit.dart
@@ -103,6 +103,7 @@ class PresentSignedDocumentCubit extends Cubit<PresentSignedDocumentState> {
   }
 
   /// Saves [signedDocument] content into given [file].
+  // TODO As extension function on SignDocumentResponseBody type
   Future<void> _saveDocumentIntoFile(File file) {
     return Future.microtask(() => base64Decode(signedDocument.content))
         .then((bytes) => file.writeAsBytes(bytes, flush: true));

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -553,12 +553,6 @@ abstract class AppLocalizations {
   /// **'Zdieľať podpísaný dokument'**
   String get shareSignedDocumentLabel;
 
-  /// No description provided for @shareSignedDocumentSubject.
-  ///
-  /// In sk, this message translates to:
-  /// **'Elektronicky podpísaný dokument'**
-  String get shareSignedDocumentSubject;
-
   /// No description provided for @shareSignedDocumentText.
   ///
   /// In sk, this message translates to:

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -294,9 +294,6 @@ class AppLocalizationsSk extends AppLocalizations {
   String get shareSignedDocumentLabel => 'Zdieľať podpísaný dokument';
 
   @override
-  String get shareSignedDocumentSubject => 'Elektronicky podpísaný dokument';
-
-  @override
   String get shareSignedDocumentText => '\n\nPodpísané aplikáciou Autogram v mobile';
 
   @override

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -95,7 +95,6 @@
   "saveSignedDocumentErrorMessage": "Pri ukladaní súboru sa vyskytla chyba:\n{error}",
 
   "shareSignedDocumentLabel": "Zdieľať podpísaný dokument",
-  "shareSignedDocumentSubject": "Elektronicky podpísaný dokument",
   "shareSignedDocumentText": "\n\nPodpísané aplikáciou Autogram v mobile",
   "shareSignedDocumentErrorMessage": "Pri zdieľaní súboru sa vyskytla chyba:\n{error}",
 

--- a/lib/ui/screens/present_signed_document_screen.dart
+++ b/lib/ui/screens/present_signed_document_screen.dart
@@ -108,7 +108,6 @@ class PresentSignedDocumentScreen extends StatelessWidget {
 
       await Share.shareXFiles(
         [XFile(file.path)],
-        subject: strings.shareSignedDocumentSubject,
         text: strings.shareSignedDocumentText,
       );
     } catch (error) {

--- a/lib/ui/screens/present_signed_document_screen.dart
+++ b/lib/ui/screens/present_signed_document_screen.dart
@@ -109,6 +109,9 @@ class PresentSignedDocumentScreen extends StatelessWidget {
       await Share.shareXFiles(
         [XFile(file.path)],
         text: strings.shareSignedDocumentText,
+        // It would be better to have something meaningful for email clients,
+        // however this is also used in Google Drive as target file name
+        subject: file.basename,
       );
     } catch (error) {
       if (context.mounted) {


### PR DESCRIPTION
Pri sharovani podpisaneho suboru sa nastavoval `subject` = "Elektronicky podpísaný dokument".
Toto je OK pre email klienta, ale v pripade **Google Drive** sa to pouzilo ako target file name a bez pripony, takze to user musel upravit.

Closes #38 