### PR TITLE
Fix workflow warnings

### DIFF
--- a/.github/workflows/android_package.yaml
+++ b/.github/workflows/android_package.yaml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   build:
     environment: packaging
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -71,13 +71,13 @@ jobs:
         run: flutter build apk --release
 
       - name: Upload .aab Build to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: release-artifacts
            path: ./app/build/app/outputs/bundle/release/app-release.aab
 
       - name: Upload .apk Build to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-artifacts
           path: ./app/build/app/outputs/apk/release/app-release.apk

--- a/.github/workflows/android_package.yaml
+++ b/.github/workflows/android_package.yaml
@@ -50,7 +50,7 @@ jobs:
         working-directory: ./app
         run: echo $ENCODED_STRING | base64 -d > release_keystore.jks
 
-      - name: Build Googla Play .aab
+      - name: Build Google Play .aab
         env:
           AVM_KEYSTORE_FILE: ../../release_keystore.jks
           AVM_KEYSTORE_PASSWORD: ${{ secrets.GOOGLE_RELEASE_KEYSTORE_PASSWORD }}
@@ -60,7 +60,7 @@ jobs:
         working-directory: ./app
         run: flutter build appbundle --release
 
-      - name: Build Andorid .apk
+      - name: Build Android .apk
         env:
           AVM_KEYSTORE_FILE: ../../release_keystore.jks
           AVM_KEYSTORE_PASSWORD: ${{ secrets.GOOGLE_RELEASE_KEYSTORE_PASSWORD }}


### PR DESCRIPTION
Update [Build and sign application for Android](https://github.com/slovensko-digital/avm-app-flutter/actions/workflows/android_package.yaml) workflow, ktory mal tieto warnings:

- **build**
ubuntu-latest pipelines will use ubuntu-24.04 soon. For more details, see https://github.com/actions/runner-images/issues/10636
- **Deprecation notice: v1, v2, and v3 of the artifact actions**
 The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "release-artifacts".
Please update your workflow to use v4 of the artifact actions.
Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Pouziva sa:
- explicitna verzia ubuntu: `ubuntu-24.04`
-  a `actions/upload-artifact@v4`

A este aj fix nazvov stepov.