### PR TITLE
Accessibility - lepsi farebny kontrast pre pripad "neznamy podpis"

### DIFF
--- a/lib/ui/widgets/document_validation_strip.dart
+++ b/lib/ui/widgets/document_validation_strip.dart
@@ -34,30 +34,39 @@ class DocumentValidationStrip extends StatelessWidget {
     final hasSignatures =
         (value.failedCount + value.indeterminateCount + value.passedCount) > 0;
     final strings = context.strings;
-    final (String text, Color backgroundColor) = switch (data) {
+    final (String text, Color foregroundColor, Color backgroundColor) =
+        switch (data) {
       (true, _, _, _) => (
           strings.documentValidationLoadingLabel,
+          Colors.white,
           const Color(0xFF126DFF)
         ),
       (false, 0, 0, 0) => (
           strings.documentValidationNoSignaturesLabel,
+          Colors.white,
           const Color(0xFF126DFF),
         ),
       (false, > 0, _, _) => (
           strings.documentValidationHasInvalidSignaturesLabel,
+          Colors.white,
           const Color(0xFFC3112B),
         ),
       (false, _, > 0, _) => (
           strings.documentValidationHasIndeterminateSignatureLabel,
-          const Color(0xFFbd730c),
+          Colors.black,
+          const Color(0xFFEBCFAA),
         ),
       (false, 0, 0, > 0) => (
           strings.documentValidationHasValidSignaturesLabel(value.passedCount),
+          Colors.white,
           const Color(0xFF078814),
         ),
-      (_, _, _, _) => ("", Colors.transparent), // technically invalid case
+      (_, _, _, _) => (
+          "",
+          Colors.black,
+          Colors.transparent
+        ), // technically invalid case
     };
-    const foregroundColor = Colors.white;
     final icon = (hasSignatures ? Icons.arrow_right_alt_outlined : Icons.close);
 
     final children = [


### PR DESCRIPTION
Fix: #87

<img width="297" height="28" alt="neplatne" src="https://github.com/user-attachments/assets/5f88627e-cf4d-4242-b8c7-ef7a13e17f09" />

---

<img width="301" height="30" alt="neznamy" src="https://github.com/user-attachments/assets/61d5abb1-27d9-4380-87b2-a46ece9365b0" />

---

<img width="256" height="29" alt="ok" src="https://github.com/user-attachments/assets/e7b32806-84ab-4fcd-af28-775d78b73d82" />

---

<img width="292" height="57" alt="ziadny" src="https://github.com/user-attachments/assets/e0afce08-4e70-48a1-bd5d-dd749054051c" />
