### PR TITLE
remove unnecessary android storage read permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,11 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools">
 
-  <uses-permission
-    android:name="android.permission.READ_EXTERNAL_STORAGE"
-    android:maxSdkVersion="32" />
-  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-
   <queries>
     <intent>
       <action android:name="android.intent.action.VIEW_DOWNLOADS" />


### PR DESCRIPTION
> Android does not require storage access when the user explicitly selects or shares a file.